### PR TITLE
Add face recognition script with unknown visitor capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Face recognition outputs
+unknown_images/
+unknown_videos/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 📋 项目概述
 
-`pi5-face-recognition-tools` 旨在利用 Raspberry Pi 5 的 CPU 指令集优化，实现实时人脸检测与识别。虽然示例脚本（如 `capture.py`、`train.py`、`recognize.py`）将于后续版本添加，本 README 主要覆盖：
+`pi5-face-recognition-tools` 旨在利用 Raspberry Pi 5 的 CPU 指令集优化，实现实时人脸检测与识别。仓库已包含一个基础的 `recognize.py` 实时识别脚本，后续将补充 `capture.py`、`train.py` 等，README 主要覆盖：
 
 - 系统与 Python 环境准备
 
@@ -100,6 +100,19 @@ pip install \
 - **OpenMP 并行**：确保 `dlib` 编译时启用 OpenMP，可用所有 CPU 核心。
 - **BLAS 加速**：`libopenblas-dev` 提供更快的线性代数运算。
 - **异步流水线**：使用多线程分离采集、检测、识别。
+
+---
+
+## 🧪 示例脚本：实时识别
+
+在 `dataset/` 目录中放置已知人员的照片（文件名作为姓名），然后运行：
+
+```bash
+python recognize.py
+```
+
+- 若检测到未在库中的陌生人，会将当前帧保存至 `unknown_images/` 并录制数秒短视频到 `unknown_videos/`。
+- 若识别到已知人员，会在终端提示并触发蜂鸣，不保存视频。
 
 ---
 

--- a/recognize.py
+++ b/recognize.py
@@ -1,0 +1,105 @@
+import os
+import cv2
+import face_recognition
+import numpy as np
+from datetime import datetime
+
+DATASET_DIR = "dataset"
+UNKNOWN_IMAGE_DIR = "unknown_images"
+UNKNOWN_VIDEO_DIR = "unknown_videos"
+VIDEO_CLIP_SECONDS = 3
+TOLERANCE = 0.5
+CAMERA_INDEX = 0
+
+
+def load_known_faces(dataset_dir):
+    """Load labeled face encodings from the dataset directory."""
+    encodings = []
+    names = []
+    for file_name in os.listdir(dataset_dir):
+        file_path = os.path.join(dataset_dir, file_name)
+        if not os.path.isfile(file_path):
+            continue
+        if not file_name.lower().endswith((".jpg", ".jpeg", ".png")):
+            continue
+        image = face_recognition.load_image_file(file_path)
+        face_encs = face_recognition.face_encodings(image)
+        if face_encs:
+            encodings.append(face_encs[0])
+            names.append(os.path.splitext(file_name)[0])
+    return encodings, names
+
+
+def alert_known(name):
+    """Simple alert when a known person is recognized."""
+    print(f"Recognized: {name}")
+    print("\a", end="")  # attempt to beep
+
+
+def save_unknown(frame, video_capture):
+    """Save the current frame and a short video clip for an unknown face."""
+    os.makedirs(UNKNOWN_IMAGE_DIR, exist_ok=True)
+    os.makedirs(UNKNOWN_VIDEO_DIR, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    image_path = os.path.join(UNKNOWN_IMAGE_DIR, f"unknown_{ts}.jpg")
+    cv2.imwrite(image_path, frame)
+
+    fps = int(video_capture.get(cv2.CAP_PROP_FPS)) or 30
+    width = int(video_capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(video_capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    video_path = os.path.join(UNKNOWN_VIDEO_DIR, f"unknown_{ts}.mp4")
+    writer = cv2.VideoWriter(video_path, fourcc, fps, (width, height))
+    for _ in range(int(fps * VIDEO_CLIP_SECONDS)):
+        ret, clip_frame = video_capture.read()
+        if not ret:
+            break
+        writer.write(clip_frame)
+    writer.release()
+    print(f"Unknown person recorded: {image_path}, {video_path}")
+
+
+def recognize():
+    known_encodings, known_names = load_known_faces(DATASET_DIR)
+    if not known_encodings:
+        print("No known faces loaded. Populate the dataset directory with images.")
+
+    video_capture = cv2.VideoCapture(CAMERA_INDEX)
+    if not video_capture.isOpened():
+        print("Cannot open camera.")
+        return
+
+    try:
+        while True:
+            ret, frame = video_capture.read()
+            if not ret:
+                break
+            small = cv2.resize(frame, (0, 0), fx=0.25, fy=0.25)
+            rgb_small = small[:, :, ::-1]
+
+            locations = face_recognition.face_locations(rgb_small)
+            encodings = face_recognition.face_encodings(rgb_small, locations)
+
+            for face_encoding in encodings:
+                matches = face_recognition.compare_faces(known_encodings, face_encoding, TOLERANCE)
+                name = "Unknown"
+                if known_encodings:
+                    distances = face_recognition.face_distance(known_encodings, face_encoding)
+                    best_index = np.argmin(distances)
+                    if matches and matches[best_index]:
+                        name = known_names[best_index]
+
+                if name == "Unknown":
+                    save_unknown(frame, video_capture)
+                else:
+                    alert_known(name)
+
+            if cv2.waitKey(1) & 0xFF == ord('q'):
+                break
+    finally:
+        video_capture.release()
+        cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    recognize()


### PR DESCRIPTION
## Summary
- add `recognize.py` demo that loads known faces from `dataset/`
- save unknown faces with short video clips and beep for known faces
- document usage and ignore generated capture directories

## Testing
- `python -m py_compile recognize.py`


------
https://chatgpt.com/codex/tasks/task_e_6892f39a83b883319c88b7701e0e89aa